### PR TITLE
Update gImageReader runtime to 46 

### DIFF
--- a/io.github.manisandro.gImageReader.yml
+++ b/io.github.manisandro.gImageReader.yml
@@ -98,8 +98,8 @@ modules:
         sources:
           - type: git
             url: https://gitlab.com/sane-project/backends.git
-            tag: 1.3.0
-            commit: 7088afe04dc83395af599b6c224b020a142e64d8
+            tag: 1.3.1
+            commit: 3ff55fd8ee04ae459e199088ebe11ac979671d0e
             x-checker-data:
               type: anitya
               project-id: 4760
@@ -139,9 +139,9 @@ modules:
         # NB: all versions are pinned below a coordinated ABI break
       - name: gtkmm
         sources:
-          - sha256: d2940c64922e5b958554b23d4c41d1839ea9e43e0d2e5b3819cfb46824a098c4
+          - sha256: 30d5bfe404571ce566a8e938c8bac17576420eb508f1e257837da63f14ad44ce
             type: archive
-            url: https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.8.tar.xz
+            url: https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.9.tar.xz
             x-checker-data:
               type: gnome
               name: gtkmm
@@ -186,9 +186,9 @@ modules:
               - /lib/sigc++-2.0
           - name: glibmm
             sources:
-              - sha256: 5358742598181e5351d7bf8da072bf93e6dd5f178d27640d4e462bc8f14e152f
+              - sha256: fe02c1e5f5825940d82b56b6ec31a12c06c05c1583cfe62f934d0763e1e542b3
                 type: archive
-                url: https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.6.tar.xz
+                url: https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.7.tar.xz
                 x-checker-data:
                   type: gnome
                   name: glibmm
@@ -338,8 +338,8 @@ modules:
               - /lib/pkgconfig
             sources:
               - type: archive
-                url: https://github.com/uclouvain/openjpeg/archive/v2.5.0.tar.gz
-                sha256: 0333806d6adecc6f7a91243b2b839ff4d2053823634d4f6ed7a59bc87409122a
+                url: https://github.com/uclouvain/openjpeg/archive/v2.5.2.tar.gz
+                sha256: 90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a
                 x-checker-data:
                   type: anitya
                   project-id: 2550
@@ -350,8 +350,8 @@ modules:
           - /lib/pkgconfig
         sources:
           - type: archive
-            url: https://poppler.freedesktop.org/poppler-24.02.0.tar.xz
-            sha256: 19187a3fdd05f33e7d604c4799c183de5ca0118640c88b370ddcf3136343222e
+            url: https://poppler.freedesktop.org/poppler-24.06.0.tar.xz
+            sha256: 0cdabd495cada11f6ee9e75c793f80daf46367b66c25a63ee8c26d0f9ec40c76
             x-checker-data:
               type: anitya
               project-id: 3686
@@ -406,8 +406,8 @@ modules:
 
         sources:
           - type: archive
-            url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.3.4.tar.gz
-            sha256: 141afc12b34a14bb691a939b4b122db0d51bd38feda7f41696822bacea7710c7
+            url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.4.0.tar.gz
+            sha256: 30ceffd9b86780f01cbf4eaf9b7fc59abddfcbaf5bbd52f9a633c6528cb183fd
             x-checker-data:
               type: anitya
               project-id: 4954

--- a/io.github.manisandro.gImageReader.yml
+++ b/io.github.manisandro.gImageReader.yml
@@ -1,7 +1,7 @@
 app-id: io.github.manisandro.gImageReader
 runtime: org.gnome.Platform
 # runtime 45 causes application crashes: https://github.com/flathub/io.github.manisandro.gImageReader/issues/31
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: gimagereader-gtk
 rename-desktop-file: gimagereader-gtk.desktop

--- a/io.github.manisandro.gImageReader.yml
+++ b/io.github.manisandro.gImageReader.yml
@@ -38,18 +38,35 @@ finish-args:
   # Scanners access
   - --device=all
 
+cleanup:
+  - /include
+  - /lib/atkmm-1.6
+  - /lib/cmake
+  - /lib/cairomm-1.0
+  - /lib/girepository-1.0
+  - /lib/gdkmm-3.0
+  - /lib/giomm-2.4
+  - /lib/glibmm-2.4
+  - /lib/gtkmm-3.0
+  - /lib/libglibmm_generate_extra_defs*
+  - /lib/openjpeg-*
+  - /lib/pangomm-1.4
+  - /lib/pkgconfig
+  - /lib/sigc++-2.0
+  - /man
+  - /share/aclocal
+  - /share/doc
+  - /share/gir-1.0
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
+  - /share/vala
+  - '*.la'
+  - '*.a'
+
 modules:
   - name: gimagereader
     buildsystem: cmake-ninja
-    cleanup:
-      - /include
-      - /lib/pkgconfig
-      - /man
-      - /share/gtk-doc
-      - /share/man
-      - /share/pkgconfig
-      - /lib/*.la
-      - '*.a'
     config-opts:
       - -DINTERFACE_TYPE=gtk
       - -DENABLE_VERSIONCHECK=0
@@ -110,7 +127,6 @@ modules:
         cleanup:
           - /bin
           - /share
-          - /lib/pkgconfig
         config-opts:
           - -DPODOFO_BUILD_LIB_ONLY=1
           - -DPODOFO_BUILD_SHARED=1
@@ -152,17 +168,6 @@ modules:
           - -Dmaintainer-mode=false
           - -Dbuild-demos=false
           - -Dbuild-tests=false
-        cleanup:
-          - '*.a'
-          - '*.la'
-          - /include
-          - /lib/gdkmm-3.0
-          - /lib/gtkmm-3.0
-          - /lib/pkgconfig
-          - /man
-          - /share/aclocal
-          - /share/man
-          - /share/pkgconfig
         modules:
           - name: sigc++
             sources:
@@ -179,11 +184,6 @@ modules:
             buildsystem: meson
             config-opts:
               - -Dbuild-examples=false
-            cleanup:
-              - '*.la'
-              - /include/sigc++-2.0
-              - /lib/pkgconfig
-              - /lib/sigc++-2.0
           - name: glibmm
             sources:
               - sha256: fe02c1e5f5825940d82b56b6ec31a12c06c05c1583cfe62f934d0763e1e542b3
@@ -198,14 +198,6 @@ modules:
             buildsystem: meson
             config-opts:
               - -Dbuild-examples=false
-            cleanup:
-              - '*.la'
-              - /include/glibmm-2.4
-              - /include/giomm-2.4
-              - /lib/glibmm-2.4
-              - /lib/giomm-2.4
-              - /lib/libglibmm_generate_extra_defs*
-              - /lib/pkgconfig
           - name: cairomm
             sources:
               - sha256: 70136203540c884e89ce1c9edfb6369b9953937f6cd596d97c78c9758a5d48db
@@ -220,11 +212,6 @@ modules:
             buildsystem: meson
             config-opts:
               - -Dbuild-examples=false
-            cleanup:
-              - '*.la'
-              - /include/cairomm-1.0
-              - /lib/cairomm-1.0
-              - /lib/pkgconfig
           - name: pangomm
             sources:
               - sha256: b92016661526424de4b9377f1512f59781f41fb16c9c0267d6133ba1cd68db22
@@ -236,11 +223,6 @@ modules:
                   versions:
                     <: '2.47'
             buildsystem: meson
-            cleanup:
-              - '*.la'
-              - /include/pangomm-1.4
-              - /lib/pangomm-1.4
-              - /lib/pkgconfig
           - name: atkmm
             sources:
               - sha256: 0a142a8128f83c001efb8014ee463e9a766054ef84686af953135e04d28fdab3
@@ -252,11 +234,6 @@ modules:
                   versions:
                     <: '2.35'
             buildsystem: meson
-            cleanup:
-              - '*.la'
-              - /include/atkmm-1.6
-              - /lib/atkmm-1.6
-              - /lib/pkgconfig
 
       - name: gtksourceviewmm
         config-opts:
@@ -333,9 +310,6 @@ modules:
             builddir: true
             cleanup:
               - /bin
-              - /include
-              - /lib/openjpeg-*
-              - /lib/pkgconfig
             sources:
               - type: archive
                 url: https://github.com/uclouvain/openjpeg/archive/v2.5.2.tar.gz
@@ -345,9 +319,6 @@ modules:
                   project-id: 2550
                   stable-only: true
                   url-template: https://github.com/uclouvain/openjpeg/archive/v$version.tar.gz
-        cleanup:
-          - /include
-          - /lib/pkgconfig
         sources:
           - type: archive
             url: https://poppler.freedesktop.org/poppler-24.06.0.tar.xz


### PR DESCRIPTION
- Update gImageReader runtime to 46 since runtime version 44 has reached end-of-life.
- Update several modules.

### Experimental: Reduce package size

- Remove redundant files to reduce package size.
- Also merge individual cleanup processes.