### PR TITLE
Get boost from boost.io instead of jfrog.io

### DIFF
--- a/io.github.manisandro.gImageReader.yml
+++ b/io.github.manisandro.gImageReader.yml
@@ -81,13 +81,13 @@ modules:
           - ./b2 -j $FLATPAK_BUILDER_N_JOBS install
         sources:
           - type: archive
-            url: https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2
+            url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2
             sha256: 1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b
             x-checker-data:
               type: anitya
               project-id: 6845
               stable-only: true
-              url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
+              url-template: https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
 
       - name: mm-common
         sources:


### PR DESCRIPTION
Fixes regularly happening errors during local build:
````
Downloading https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2
100   138  100   138    0     0    201      0 --:--:-- --:--:-- --:--:--  1159
100 11533  100 11533    0     0   8264      0  0:00:01  0:00:01 --:--:--  8264
Failed to download sources: module boost: Wrong sha256 checksum for boost_1_86_0.tar.bz2, expected "1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b", was "e0f020de72913559199b5698b1f50a733dcfd7e1b
0532de4a2357c3baca95e0f"
````