### PR TITLE
Remove mm-common

### DIFF
--- a/io.github.manisandro.gImageReader.yml
+++ b/io.github.manisandro.gImageReader.yml
@@ -87,16 +87,6 @@ modules:
               stable-only: true
               url-template: https://archives.boost.io/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2
 
-      - name: mm-common
-        sources:
-          - type: archive
-            url: https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.7.tar.xz
-            sha256: 494abfce781418259b1e9d8888c73af4de4b6f3be36cc75d9baa8baa0f2a7a39
-            x-checker-data:
-              type: gnome
-              name: mm-common
-              stable-only: true
-
       - name: sane-backends
         buildsystem: autotools
         config-opts:
@@ -312,8 +302,9 @@ modules:
               url-template: https://poppler.freedesktop.org/poppler-$version.tar.xz
 
       - name: libxml++
+        buildsystem: meson
         config-opts:
-          - --disable-documentation
+          - -Dbuild-examples=false
         sources:
           - type: archive
             url: https://download.gnome.org/sources/libxml++/3.2/libxml++-3.2.5.tar.xz


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs, mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80